### PR TITLE
Default to https as the scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,53 @@ The source code for the VersionOne Python SDK is free and open-source, and we en
 
 ## Overview
 
+### Instantiating a connection
+
+To interact, you must first create an instance of the `V1Meta` object.  This requires you to specify how to connect to the server.
+
+There are two options, specifying the full URL to your instance directly, or specifying individual details.
+
+```python
+from v1pysdk import V1Meta
+
+with V1Meta(
+  instance_url = 'http://localhost/VersionOne',
+  # any instance, scheme, or address values will be ignored
+  username = 'admin',
+  password = 'admin'
+  ) as v1:
+```
+
+Alternatively
+
+```python
+from v1pysdk import V1Meta
+
+with V1Meta(
+  address = 'localhost',
+  instance = 'VersionOne',
+  scheme = 'http', #optional, defaults to https
+  username = 'admin',
+  password = 'admin'
+  ) as v1:
+```
+
+To authenticate, two methods are provided, username and password as demonstrated above, or Access Tokens.
+Tokens are created by logging in to VersionOne via the web interface, going to the user's profile, going to Applications, and creating a new application.  This will provide an Access Token that looks something like `1.2cFHe7NkoO1kOV/x8WLpw1NasJg=`.  KEEP THIS SECRET since it's the secret API access key for your specific user on your instance.
+
+To use an access token, you use it as your password and set the flag indicating it's really an Access Token.  This will no longer require a username to be present.
+
+```python
+from v1pysdk import V1Meta
+
+with V1Meta(
+  address = 'localhost',
+  instance = 'VersionOne',
+  password = '1.2cFHe7NkoO1kOV/x8WLpw1NasJg=',
+  use_password_as_token=True,
+  ) as v1:
+```
+
 ### Dynamic reflection of all V1 asset types:
 
   Just instantiate a V1Meta.  All asset types defined on the server are available

--- a/v1pysdk/client.py
+++ b/v1pysdk/client.py
@@ -64,7 +64,7 @@ class V1AssetNotFoundError(V1Error):
 class V1Server(object):
   "Accesses a V1 HTTP server as a client of the XML API protocol"
 
-  def __init__(self, address="localhost", instance="VersionOne.Web", username='', password='', scheme="http", instance_url=None, logparent=None, loglevel=logging.ERROR, use_password_as_token=False):
+  def __init__(self, address="localhost", instance="VersionOne.Web", username='', password='', scheme="https", instance_url=None, logparent=None, loglevel=logging.ERROR, use_password_as_token=False):
     if instance_url:
       self.instance_url = instance_url
       parsed = urlparse(instance_url)


### PR DESCRIPTION
The V1 host can be specified as either an instance_url or as an address and instance.  When using the second option, the scheme has to be assumed, and the default was http.  That causes problems now on public and test servers, so change it to https by default.

/closes #8 