### PR TITLE
Fix http POST commands

### DIFF
--- a/v1pysdk/client.py
+++ b/v1pysdk/client.py
@@ -104,8 +104,8 @@ class V1Server(object):
 
   def http_post(self, url, data=''):
     encodedData=data
-    #encode to byte data as is needed if in Python3 or Python2 and it's a string
-    if (sys.version_info >= (3,0)) or isinstance(data, str):
+    #encode to byte data as is needed if  it's a string
+    if isinstance(data, str):
         encodedData=data.encode('utf-8')
     request = Request(url, encodedData)
     request.add_header("Content-Type", "text/xml;charset=UTF-8")

--- a/v1pysdk/client.py
+++ b/v1pysdk/client.py
@@ -103,7 +103,11 @@ class V1Server(object):
     return response
 
   def http_post(self, url, data=''):
-    request = Request(url, data)
+    encodedData=data
+    #encode to byte data as is needed if in Python3 or Python2 and it's a string
+    if (sys.version_info >= (3,0)) or isinstance(data, str):
+        encodedData=data.encode('utf-8')
+    request = Request(url, encodedData)
     request.add_header("Content-Type", "text/xml;charset=UTF-8")
     response = self.opener.open(request)
     return response


### PR DESCRIPTION
There was a bug with the python 2->3 conversion where data provided to the urllib.request.Request object must be set to trigger a POST instead of a GET, but also can't be a string.

This was causing a TypeError to be thrown by urllib when triggering POST commands that needed no extra arguments (e.g. QuickClose operation on stories).