### PR TITLE
Fix memoization decorator, fix connection errors

### DIFF
--- a/v1pysdk/cache_decorator.py
+++ b/v1pysdk/cache_decorator.py
@@ -1,25 +1,25 @@
+def key_by_args_and_func_kw(old_f, args, kw, cache_data):
+    """Function to produce a key hash for the cache_data hash based on the function and the arguments
+       provided."""
+    return repr((old_f, args, kw))
 
-def key_by_args_kw(old_f, args, kw, cache_data):
-  'Function to build a cache key for the cached_by_keyfunc decorator. '
-  'This one just caches based on the function call arguments. i.e. Memoize '
-  return repr((args, kw))
 
-
-def cached_by_keyfunc(keyfunc):
-  """Calls keyfunc with (old_f, args, kw, datadict) to get cache key """
-  def decorator(old_f):
-    data = {}
+def memoized(old_f):
+    """Decorator that memoizes calls to old_f into a single instance-specific _memoized_data hash"""
     def new_f(self, *args, **kw):
-      new_key = keyfunc(old_f, args, kw, data)
-      if new_key in data:
-        return data[new_key]
-      new_value = old_f(self, *args, **kw)
-      data[new_key] = new_value
-      return new_value
+        """Function to wrap the decorated method"""
+        if not self._memoized_data:
+            self._memoized_data = {}
+        #generate a hash using the provided hashing function from the closure
+        new_key = key_by_args_and_func_kw(old_f, args, kw, self._memoized_data)
+        # check if it's already in the memoized data
+        if new_key in  self._memoized_data:
+            # return what's already there
+            return self._memoized_data[new_key]
+        # not found, call the real function and put the results in the memoized data
+        new_value = old_f(self, *args, **kw)
+        self._memoized_data[new_key] = new_value
+        return new_value
     return new_f
-  return decorator
 
-
-memoized = cached_by_keyfunc(key_by_args_kw)
-
-
+#memoized = cached_by_keyfunc()

--- a/v1pysdk/client.py
+++ b/v1pysdk/client.py
@@ -24,7 +24,7 @@ except ImportError:
     from elementtree import ElementTree
     from elementtree.ElementTree import Element
 
-AUTH_HANDLERS = [HTTPBasicAuthHandler]
+NTLM_FOUND=False
 
 try:
     if (sys.version_info < (3,0)):
@@ -34,24 +34,7 @@ try:
 except ImportError:
     logging.warn("Windows integrated authentication module (ntlm) not found.")
 else:
-    class CustomHTTPNtlmAuthHandler(HTTPNtlmAuthHandler):
-        """ A version of HTTPNtlmAuthHandler that handles errors (better).
-
-            The default version doesn't use `self.parent.open` in it's
-            error handler, and completely bypasses the normal `OpenerDirector`
-            call chain, most importantly `HTTPErrorProcessor.http_response`,
-            which normally raises an error for 'bad' http status codes..
-        """
-        def http_error_401(self, req, fp, code, msg, hdrs):
-            response = HTTPNtlmAuthHandler.http_error_401(self, req, fp, code, msg, hdrs)
-            if not (200 <= response.code < 300):
-                response = self.parent.error(
-                        'http', req, response, response.code, response.msg,
-                        response.info)
-            return response
-
-    AUTH_HANDLERS.append(CustomHTTPNtlmAuthHandler)
-
+    NTLM_FOUND=True
 
 class V1Error(Exception):
     pass
@@ -76,7 +59,9 @@ class V1Server(object):
       self.instance = instance.strip('/')
       self.scheme = scheme
       self.instance_url = self.build_url('')
-
+    self.AUTH_HANDLERS = [HTTPBasicAuthHandler]
+    if NTLM_FOUND:
+        self.AUTH_HANDLERS.append(HTTPNtlmAuthHandler)
     modulelogname='v1pysdk.client'
     logname = "%s.%s" % (logparent, modulelogname) if logparent else None
     self.logger = logging.getLogger(logname)
@@ -89,8 +74,8 @@ class V1Server(object):
   def _install_opener(self):
     base_url = self.build_url('')
     password_manager = theUrlLib.HTTPPasswordMgrWithDefaultRealm()
-    password_manager.add_password(None, base_url, self.username, self.password)
-    handlers = [HandlerClass(password_manager) for HandlerClass in AUTH_HANDLERS]
+    password_manager.add_password(realm=None, uri=base_url, user=self.username, passwd=self.password)
+    handlers = [HandlerClass(password_manager) for HandlerClass in self.AUTH_HANDLERS]
     self.opener = theUrlLib.build_opener(*handlers)
     if self.use_password_as_token:
         self.opener.addheaders.append(('Authorization', 'Bearer ' + self.password))


### PR DESCRIPTION
Fixed the `@memoized` decorator rather than the previous hacked fix.
Fixed authentication error handling in V1Server
Added unittests that confirm invalid connections do fail, and new V1Meta objects have independent credential content now (confirm `@memoized` decorator works properly now)
Fixed how the find test of the query test set works so it passes.

/closes #4 
/closed #5 