### PR TITLE
Update setup.py to add new Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
       "Programming Language :: Python :: 2.7",
       "Programming Language :: Python :: 3",
       "Programming Language :: Python :: 3.5",
+      "Programming Language :: Python :: 3.6",
+      "Programming Language :: Python :: 3.7",
       "Topic :: Software Development :: Bug Tracking",
       ),
 


### PR DESCRIPTION
Since Python 3.x releases are all compatible with each other, we can list full Python 3 compatibility on the PyPi archive.